### PR TITLE
Add possibility to inject our own http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Client implementations for Bitstamp's HTTP (REST) and Websocket APIs in Go. Webs
 
 ## Requirements
 
-* Go 1.18+
-* Dependencies in `go.mod`
+- Go 1.22+
+- Dependencies in `go.mod`
 
 ## Usage examples
 
@@ -20,13 +20,13 @@ $ go run examples/http/main.go
 
 ## TODO
 
-* Configure GitHub Actions.
-* Update pairs config.
-* Finish implementing all the endpoints.
-* Remove/deprecate REST v1.
-* Godoc / documentation.
-* More tests.
-* E2E tests against Bitstamp's API.
-* Docker builds.
-* Authors file / information?
-* Shadow order book creation. (Is this an example? A separate project even?)
+- Configure GitHub Actions.
+- Update pairs config.
+- Finish implementing all the endpoints.
+- Remove/deprecate REST v1.
+- Godoc / documentation.
+- More tests.
+- E2E tests against Bitstamp's API.
+- Docker builds.
+- Authors file / information?
+- Shadow order book creation. (Is this an example? A separate project even?)

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -3,14 +3,32 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
+	nethttp "net/http"
+	"time"
 
 	"github.com/bitstonks/bitstamp-go/pkg/http"
 	"github.com/shopspring/decimal"
 )
 
 func main() {
+	// Configure more sane timeouts for http client
+	t := nethttp.DefaultTransport.(*nethttp.Transport).Clone()
+	t.MaxIdleConns = 100
+	t.MaxConnsPerHost = 100
+	t.MaxIdleConnsPerHost = 100
+	t.DialContext = (&net.Dialer{Timeout: 2 * time.Second}).DialContext
+
+	httpClient := &nethttp.Client{
+		Timeout:   10 * time.Second,
+		Transport: t,
+	}
+
+	// construct the Bitstamp API client
 	api := http.NewHttpClient(
 		http.Credentials("invalid", "invalid"),
+		http.WithHttpClient(httpClient),    // optional, defaults to `http.DefaultClient{}`
+		http.RequestTimeout(5*time.Second), // optional, defaults to 10s
 	)
 	currencyPair := "btcusd-perp"
 	market := "BTC/USD-PERP"


### PR DESCRIPTION
Go's default http client does not define any default timeouts. In order to code more defensively it would be nice to be able to use our own http client. Also, I've added a configurable request timeout for this same reason.
